### PR TITLE
feat(auth): add API endpoint to redirect user to initial Discord OAuth2 authorize page

### DIFF
--- a/functions/api/auth/initiate.ts
+++ b/functions/api/auth/initiate.ts
@@ -1,0 +1,13 @@
+import type { Env } from '../../types'
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+	const { request, env } = context
+	const url = new URL(request.url)
+
+	return Response.redirect(getDiscordLoginUrl(url.origin, env.DISCORD_CLIENT_ID))
+}
+
+function getDiscordLoginUrl(origin: string, clientId: string) {
+	const redirectUri = encodeURIComponent(`${origin}/api/auth/discord_login`)
+	return `https://discord.com/api/oauth2/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=identify+guilds`
+}

--- a/src/index.html
+++ b/src/index.html
@@ -22,10 +22,10 @@
           <span class="fg-font">Overwatch Textures</span>
         </div>
         <div>
-          <a ng-if="!$vm.user" href="{{$vm.getDiscordLoginUrl()}}" class="btn btn-primary">
+          <a ng-if="!$vm.user" href="/api/auth/initiate" class="btn btn-primary">
             Login with Discord
           </a>
-          
+
           <div ng-if="$vm.user" class="btn-group" uib-dropdown>
             <button type="button" class="btn btn-primary" uib-dropdown-toggle>
               {{$vm.user.name}} <span class="caret"></span>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -126,11 +126,6 @@ app.controller('RootCtrl', ['$scope', '$http', '$location', function($scope, $ht
     }
   }
 
-  this.getDiscordLoginUrl = () => {
-    const redirectUri = encodeURIComponent(`${location.origin}/api/auth/discord_login`)  
-    return `https://discord.com/api/oauth2/authorize?client_id=1343405239872786543&redirect_uri=${redirectUri}&response_type=code&scope=identify+guilds`
-  }
-
   function parseJwt(token) {
     try {
       const base64Url = token.split('.')[1]


### PR DESCRIPTION
Allows us to remove the hardcoded client ID from the frontend code.